### PR TITLE
Potential fix for code scanning alert no. 33: Shell command built from environment values

### DIFF
--- a/build/azure-pipelines/publish-types/update-types.ts
+++ b/build/azure-pipelines/publish-types/update-types.ts
@@ -16,7 +16,7 @@ try {
 
 	const dtsUri = `https://raw.githubusercontent.com/microsoft/vscode/${tag}/src/vscode-dts/vscode.d.ts`;
 	const outPath = path.resolve(process.cwd(), 'DefinitelyTyped/types/vscode/index.d.ts');
-	cp.execSync(`curl ${dtsUri} --output ${outPath}`);
+	cp.execFileSync('curl', [dtsUri, '--output', outPath]);
 
 	updateDTSFile(outPath, tag);
 


### PR DESCRIPTION
Potential fix for [https://github.com/pwnautopilots/vscode/security/code-scanning/33](https://github.com/pwnautopilots/vscode/security/code-scanning/33)

To fix the issue, we should avoid dynamically constructing the shell command as a single string. Instead, we can use `cp.execFileSync`, which allows us to pass the command and its arguments separately. This approach ensures that the arguments are not interpreted by the shell, mitigating the risk of command injection.

Specifically:
1. Replace the `cp.execSync` call on line 19 with `cp.execFileSync`.
2. Pass `curl` as the command and the URL (`dtsUri`) and output path (`--output`, `outPath`) as separate arguments.
3. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
